### PR TITLE
Sam module bug fix

### DIFF
--- a/include/btllib/seq_reader_sam_module.hpp
+++ b/include/btllib/seq_reader_sam_module.hpp
@@ -122,7 +122,7 @@ SeqReaderSamModule::buffer_valid(const char* buffer, const size_t size)
           }
           break;
         case TLEN:
-          if (!bool(std::isdigit(c))) {
+          if (!bool(std::isdigit(c) || c == '-')) {
             return false;
           }
           break;

--- a/include/btllib/seq_reader_sam_module.hpp
+++ b/include/btllib/seq_reader_sam_module.hpp
@@ -122,7 +122,7 @@ SeqReaderSamModule::buffer_valid(const char* buffer, const size_t size)
           }
           break;
         case TLEN:
-          if (!bool(std::isdigit(c) || c == '-')) {
+          if (!(bool(std::isdigit(c)) || c == '-')) {
             return false;
           }
           break;


### PR DESCRIPTION
`tlen` column of SAM file can be negative, [reference](https://samtools.github.io/hts-specs/SAMv1.pdf). The PR allows the column to have `-` before digits :).