### PR TITLE
Fix wrap's sed error on BSD/Mac

### DIFF
--- a/scripts/wrap
+++ b/scripts/wrap
@@ -102,4 +102,10 @@ swig -python -py3 -fastproxy -fastdispatch -builtin -c++ -Iinclude btllib.i
 rm -f include
 
 # The following line is necessary because SWIG produces inconsistent code that cannot be compiled on all platforms. On some platforms, uint64_t is unsigned long int and unsigned long long int on others.
-sed -i 's~unsigned long long~uint64_t~g' btllib_wrap.cxx
+if [ "$(uname)" == "Darwin" ]; then
+  # MacOS
+  sed -i '' 's~unsigned long long~uint64_t~g' btllib_wrap.cxx
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  # GNU/Linux
+  sed -i 's~unsigned long long~uint64_t~g' btllib_wrap.cxx
+fi


### PR DESCRIPTION
Fixes bcgsc/btllib#42.
Tested on mac. `sed` without `-i` works fine anyway.