### PR TITLE
Indexlr mx filter

### DIFF
--- a/recipes/indexlr.cpp
+++ b/recipes/indexlr.cpp
@@ -98,7 +98,6 @@ main(int argc, char* argv[])
     bool verbose = false;
     unsigned k = 0, w = 0, t = DEFAULT_THREADS;
     size_t q = 0;
-    std::string filter_mode("");
     bool w_set = false;
     bool k_set = false;
     bool q_set = false;

--- a/recipes/indexlr.cpp
+++ b/recipes/indexlr.cpp
@@ -43,7 +43,7 @@ print_usage()
   std::cerr
     << "Usage: " << PROGNAME
     << " -k K -w W [-q Q]  [-r repeat_bf_path] [-s solid_bf_path] [--id] "
-       "[--bx] [--pos] [--seq] [--qual] [--filter-mode]"
+       "[--bx] [--pos] [--seq] [--qual] [--q-drop]"
        "[-o FILE] FILE...\n\n"
        "  -k K        Use K as k-mer size.\n"
        "  -w W        Use W as sliding-window size.\n"

--- a/recipes/indexlr.cpp
+++ b/recipes/indexlr.cpp
@@ -43,12 +43,14 @@ print_usage()
   std::cerr
     << "Usage: " << PROGNAME
     << " -k K -w W [-q Q]  [-r repeat_bf_path] [-s solid_bf_path] [--id] "
-       "[--bx] [--pos] [--seq] [--qual]"
+       "[--bx] [--pos] [--seq] [--qual] [--filter-mode]"
        "[-o FILE] FILE...\n\n"
        "  -k K        Use K as k-mer size.\n"
        "  -w W        Use W as sliding-window size.\n"
        "  -q Q        Filter kmers with average quality (Phred score) lower "
        "than Q [0].  \n"
+       "  --q-drop    Drop filtered kemrs instead of disqualifying from generating minimizers. \n"
+       "  --part-avg  Consider only 1/10 of the (lowest value) base quality scores  for averaging. \n"
        "  --id        Include input sequence ids in the output. "
        "(Default if --bx is not provided)\n"
        "  --bx        Include input sequence barcodes in the output.\n"
@@ -96,11 +98,12 @@ main(int argc, char* argv[])
     bool verbose = false;
     unsigned k = 0, w = 0, t = DEFAULT_THREADS;
     size_t q = 0;
+    std::string filter_mode("");
     bool w_set = false;
     bool k_set = false;
     bool q_set = false;
     int with_id = 0, with_bx = 0, with_len = 0, with_pos = 0, with_strand = 0,
-        with_seq = 0, with_qual = 0;
+        with_seq = 0, with_qual = 0, with_q_drop = 0, with_part_avg = 0;
     std::unique_ptr<btllib::KmerBloomFilter> repeat_bf, solid_bf;
     bool with_repeat = false, with_solid = false;
     int long_mode = 0;
@@ -113,6 +116,8 @@ main(int argc, char* argv[])
       { "pos", no_argument, &with_pos, 1 },
       { "strand", no_argument, &with_strand, 1 },
       { "seq", no_argument, &with_seq, 1 },
+      { "q-drop", no_argument, &with_q_drop, 1 },
+      { "part-avg", no_argument, &with_part_avg, 1 },
       { "qual", no_argument, &with_qual, 1 },
       { "long", no_argument, &long_mode, 1 },
       { "help", no_argument, &help, 1 },
@@ -230,6 +235,12 @@ main(int argc, char* argv[])
     }
     if (bool(with_qual)) {
       flags |= btllib::Indexlr::Flag::QUAL;
+    }
+    if (bool(with_q_drop)) {
+      flags |= btllib::Indexlr::Flag::Q_DROP;
+    }
+    if (bool(with_part_avg)) {
+      flags |= btllib::Indexlr::Flag::PART_AVG;
     }
     if (bool(long_mode)) {
       flags |= btllib::Indexlr::Flag::LONG_MODE;


### PR DESCRIPTION
For filtering some unwanted minimizer kmers, we used to mask them (disqualifying them from generating minimizes by setting their hash value to max) which allowed some other adjacent kmers to develop false minimizers. This code enables an alternative approach: allow the unwanted kmers to generate minimizers, but then don't output minimizers originated from unwanted kmers.