### PR TITLE
Use size_t for block number

### DIFF
--- a/include/btllib/order_queue.hpp
+++ b/include/btllib/order_queue.hpp
@@ -66,7 +66,7 @@ public:
 
     std::vector<T> data;
     size_t count = 0;
-    uint64_t num = 0;
+    size_t num = 0;
   };
 
   // Surrounds pieces of data in the buffer with a busy mutex


### PR DESCRIPTION
This pull request fixes https://github.com/bcgsc/btllib/issues/80 by ensuring that queue wait condition uses the same 
integer type. 

This limits number of blocks to MAX_UINT32 for 32bit architectures, but it is unlikely to hit it due to other architecture limitations (e.g. ram size). 
Alternative is to update the wait condition and avoid relying on integer overflow. 
