### PR TITLE
Fix gcovr

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,14 @@ jobs:
 
   - script: |
       source activate btllib_CI
+      set -o errexit -o pipefail
+      ./compile
+      cd examples
+      g++ nthash_spacedseeds.cpp -I../install/include -L../install/lib -lbtllib && ./a
+    displayName: 'Compile example'
+
+  - script: |
+      source activate btllib_CI
       cd build && ninja clang-format-check
     displayName: 'Run clang-format'
 
@@ -89,6 +97,14 @@ jobs:
       source activate btllib_CI
       meson setup build && cd build && ninja
     displayName: 'Build the project'
+  
+  - script: |
+      source activate btllib_CI
+      set -o errexit -o pipefail
+      ./compile
+      cd examples
+      g++ nthash_spacedseeds.cpp -I../install/include -L../install/lib -lbtllib && ./a.out
+    displayName: 'Compile example'
 
   - script: |
       source activate btllib_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       set -o errexit -o pipefail
       ./compile
       cd examples
-      g++ nthash_spacedseeds.cpp -I../install/include -L../install/lib -lbtllib && ./a.out
+      g++ nthash_spacedseeds.cpp -std=c++11 -I../install/include -L../install/lib -lbtllib && ./a.out
     displayName: 'Compile example'
 
   - script: |
@@ -103,7 +103,7 @@ jobs:
       set -o errexit -o pipefail
       ./compile
       cd examples
-      g++ nthash_spacedseeds.cpp -I../install/include -L../install/lib -lbtllib && ./a.out
+      g++ nthash_spacedseeds.cpp -std=c++11 -I../install/include -L../install/lib -lbtllib && ./a.out
     displayName: 'Compile example'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       set -o errexit -o pipefail
       ./compile
       cd examples
-      g++ nthash_spacedseeds.cpp -I../install/include -L../install/lib -lbtllib && ./a
+      g++ nthash_spacedseeds.cpp -I../install/include -L../install/lib -lbtllib && ./a.out
     displayName: 'Compile example'
 
   - script: |

--- a/compile
+++ b/compile
@@ -186,7 +186,7 @@ if __name__ == "__main__":
       . {venv_path}/bin/activate;
     fi &&
     {ar}
-    meson setup --buildtype release {lto} -Db_ndebug=true --prefix={args.prefix} {build_dir} &&
+    meson setup --buildtype release {lto} -Db_ndebug=true -Db_coverage=false --prefix={args.prefix} {build_dir} &&
     cd {build_dir} &&
     ninja install &&
     cd .. &&


### PR DESCRIPTION
- Fixed necessity to add coverage flags when compiling programs depending on btllib
- Added a "compile example" stage to CI to catch similar issues in the future