### PR TITLE
Bash strict mode and minor fixes

### DIFF
--- a/include/btllib/aahash.hpp
+++ b/include/btllib/aahash.hpp
@@ -48,7 +48,7 @@ aa_modify_base_with_seed(uint64_t hash_value,
     if (seed[i] != 1) {
       hash_value ^= AA_ROLL_TABLE((unsigned char)kmer_seq[i], 1, k - 1 - i);
       if (seed[i] != 0) {
-        unsigned level = seed[i];
+        const unsigned level = seed[i];
         hash_value ^=
           AA_ROLL_TABLE((unsigned char)kmer_seq[i], level, k - 1 - i);
       }

--- a/include/btllib/nthash.hpp
+++ b/include/btllib/nthash.hpp
@@ -675,10 +675,14 @@ BTLLIB_NTHASH_PEEK(
   peek(),
 
   {
-    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(
+      new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));
@@ -709,10 +713,14 @@ BTLLIB_NTHASH_PEEK(
   peek(char char_in),
 
   {
-    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(
+      new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));
@@ -744,10 +752,14 @@ BTLLIB_NTHASH_PEEK(
   peek_back(),
 
   {
-    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(
+      new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));
@@ -778,10 +790,14 @@ BTLLIB_NTHASH_PEEK(
   peek_back(char char_in),
 
   {
-    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(
+      new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(
+      new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));

--- a/include/btllib/nthash.hpp
+++ b/include/btllib/nthash.hpp
@@ -675,10 +675,10 @@ BTLLIB_NTHASH_PEEK(
   peek(),
 
   {
-    std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));
@@ -709,10 +709,10 @@ BTLLIB_NTHASH_PEEK(
   peek(char char_in),
 
   {
-    std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));
@@ -744,10 +744,10 @@ BTLLIB_NTHASH_PEEK(
   peek_back(),
 
   {
-    std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));
@@ -778,10 +778,10 @@ BTLLIB_NTHASH_PEEK(
   peek_back(char char_in),
 
   {
-    std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
-    std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> fh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> rh_no_monomers_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> forward_hash_tmp(new uint64_t[blocks.size()]);
+    const std::unique_ptr<uint64_t[]> reverse_hash_tmp(new uint64_t[blocks.size()]);
     std::memcpy(fh_no_monomers_tmp.get(),
                 forward_hash.get(),
                 blocks.size() * sizeof(uint64_t));

--- a/include/btllib/nthash_lowlevel.hpp
+++ b/include/btllib/nthash_lowlevel.hpp
@@ -105,24 +105,24 @@ ntf64(const char* kmer_seq, unsigned k)
   uint64_t h_val = 0;
   for (unsigned i = 0; i < k / 4; i++) {
     h_val = srol(h_val, 4);
-    uint8_t curr_offset = 4 * i;
-    uint8_t tetramer_loc =
+    const uint8_t curr_offset = 4 * i;
+    const uint8_t tetramer_loc =
       64 * CONVERT_TAB[(unsigned char)kmer_seq[curr_offset]] +     // NOLINT
       16 * CONVERT_TAB[(unsigned char)kmer_seq[curr_offset + 1]] + // NOLINT
       4 * CONVERT_TAB[(unsigned char)kmer_seq[curr_offset + 2]] +
       CONVERT_TAB[(unsigned char)kmer_seq[curr_offset + 3]];
     h_val ^= TETRAMER_TAB[tetramer_loc];
   }
-  unsigned remainder = k % 4;
+  const unsigned remainder = k % 4;
   h_val = srol(h_val, remainder);
   if (remainder == 3) {
-    uint8_t trimer_loc =
+    const uint8_t trimer_loc =
       16 * CONVERT_TAB[(unsigned char)kmer_seq[k - 3]] + // NOLINT
       4 * CONVERT_TAB[(unsigned char)kmer_seq[k - 2]] +
       CONVERT_TAB[(unsigned char)kmer_seq[k - 1]];
     h_val ^= TRIMER_TAB[trimer_loc];
   } else if (remainder == 2) {
-    uint8_t dimer_loc = 4 * CONVERT_TAB[(unsigned char)kmer_seq[k - 2]] +
+    const uint8_t dimer_loc = 4 * CONVERT_TAB[(unsigned char)kmer_seq[k - 2]] +
                         CONVERT_TAB[(unsigned char)kmer_seq[k - 1]];
     h_val ^= DIMER_TAB[dimer_loc];
   } else if (remainder == 1) {
@@ -144,15 +144,15 @@ inline uint64_t
 ntr64(const char* kmer_seq, unsigned k)
 {
   uint64_t h_val = 0;
-  unsigned remainder = k % 4;
+  const unsigned remainder = k % 4;
   if (remainder == 3) {
-    uint8_t trimer_loc =
+    const uint8_t trimer_loc =
       16 * RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 1]] + // NOLINT
       4 * RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 2]] +
       RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 3]];
     h_val ^= TRIMER_TAB[trimer_loc];
   } else if (remainder == 2) {
-    uint8_t dimer_loc = 4 * RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 1]] +
+    const uint8_t dimer_loc = 4 * RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 1]] +
                         RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 2]];
     h_val ^= DIMER_TAB[dimer_loc];
   } else if (remainder == 1) {
@@ -160,8 +160,8 @@ ntr64(const char* kmer_seq, unsigned k)
   }
   for (unsigned i = 0; i < k / 4; i++) {
     h_val = srol(h_val, 4);
-    uint8_t curr_offset = 4 * (k / 4 - i) - 1;
-    uint8_t tetramer_loc =
+    const uint8_t curr_offset = 4 * (k / 4 - i) - 1;
+    const uint8_t tetramer_loc =
       64 * RC_CONVERT_TAB[(unsigned char)kmer_seq[curr_offset]] +     // NOLINT
       16 * RC_CONVERT_TAB[(unsigned char)kmer_seq[curr_offset - 1]] + // NOLINT
       4 * RC_CONVERT_TAB[(unsigned char)kmer_seq[curr_offset - 2]] +
@@ -376,7 +376,7 @@ nte64(uint64_t bh_val, unsigned k, unsigned h, uint64_t* h_val)
 inline void
 ntmc64(const char* kmer_seq, unsigned k, unsigned m, uint64_t* h_val)
 {
-  uint64_t b_val = ntc64(kmer_seq, k);
+  const uint64_t b_val = ntc64(kmer_seq, k);
   nte64(b_val, k, m, h_val);
 }
 
@@ -399,7 +399,7 @@ ntmc64(const char* kmer_seq,
        uint64_t& rh_val,
        uint64_t* h_val)
 {
-  uint64_t b_val = ntc64(kmer_seq, k, fh_val, rh_val);
+  const uint64_t b_val = ntc64(kmer_seq, k, fh_val, rh_val);
   nte64(b_val, k, m, h_val);
 }
 
@@ -423,7 +423,7 @@ ntmc64(unsigned char char_out,
        uint64_t& rh_val,
        uint64_t* h_val)
 {
-  uint64_t b_val = ntc64(char_out, char_in, k, fh_val, rh_val);
+  const uint64_t b_val = ntc64(char_out, char_in, k, fh_val, rh_val);
   nte64(b_val, k, m, h_val);
 }
 
@@ -447,7 +447,7 @@ ntmc64l(unsigned char char_out,
         uint64_t& rh_val,
         uint64_t* h_val)
 {
-  uint64_t b_val = ntc64l(char_out, char_in, k, fh_val, rh_val);
+  const uint64_t b_val = ntc64l(char_out, char_in, k, fh_val, rh_val);
   nte64(b_val, k, m, h_val);
 }
 
@@ -674,7 +674,7 @@ ntmc64(unsigned char char_out,
        uint64_t* h_val,
        bool& h_stn)
 {
-  uint64_t b_val = ntc64(char_out, char_in, k, fh_val, rh_val);
+  const uint64_t b_val = ntc64(char_out, char_in, k, fh_val, rh_val);
   h_stn = rh_val < fh_val;
   nte64(b_val, k, m, h_val);
 }
@@ -806,7 +806,7 @@ ntmsm64(const char* kmer_seq,
     }
     fh_nomonos[i_seed] = fh_seed;
     rh_nomonos[i_seed] = rh_seed;
-    for (unsigned pos : seeds_monomers[i_seed]) {
+    for (const unsigned pos : seeds_monomers[i_seed]) {
       fh_seed ^= MS_TAB((unsigned char)kmer_seq[pos], k - 1 - pos);
       rh_seed ^= MS_TAB((unsigned char)kmer_seq[pos] & CP_OFF, pos);
     }

--- a/include/btllib/nthash_lowlevel.hpp
+++ b/include/btllib/nthash_lowlevel.hpp
@@ -123,7 +123,7 @@ ntf64(const char* kmer_seq, unsigned k)
     h_val ^= TRIMER_TAB[trimer_loc];
   } else if (remainder == 2) {
     const uint8_t dimer_loc = 4 * CONVERT_TAB[(unsigned char)kmer_seq[k - 2]] +
-                        CONVERT_TAB[(unsigned char)kmer_seq[k - 1]];
+                              CONVERT_TAB[(unsigned char)kmer_seq[k - 1]];
     h_val ^= DIMER_TAB[dimer_loc];
   } else if (remainder == 1) {
     h_val ^= SEED_TAB[(unsigned char)kmer_seq[k - 1]];
@@ -152,8 +152,9 @@ ntr64(const char* kmer_seq, unsigned k)
       RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 3]];
     h_val ^= TRIMER_TAB[trimer_loc];
   } else if (remainder == 2) {
-    const uint8_t dimer_loc = 4 * RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 1]] +
-                        RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 2]];
+    const uint8_t dimer_loc =
+      4 * RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 1]] +
+      RC_CONVERT_TAB[(unsigned char)kmer_seq[k - 2]];
     h_val ^= DIMER_TAB[dimer_loc];
   } else if (remainder == 1) {
     h_val ^= SEED_TAB[(unsigned char)kmer_seq[k - 1] & CP_OFF];

--- a/recipes/indexlr.cpp
+++ b/recipes/indexlr.cpp
@@ -177,7 +177,7 @@ main(int argc, char* argv[])
                     " threads does not scale, reverting to 5.\n")
                 << std::flush;
     }
-    std::vector<std::string> infiles(&argv[optind], &argv[argc]);
+    const std::vector<std::string> infiles(&argv[optind], &argv[argc]);
     if (argc < 2) {
       print_usage();
       std::exit(EXIT_FAILURE); // NOLINT(concurrency-mt-unsafe)
@@ -335,7 +335,7 @@ main(int argc, char* argv[])
           }
         }
         {
-          std::unique_lock<std::mutex> lock(output_queue_mutex);
+          const std::unique_lock<std::mutex> lock(output_queue_mutex);
           if (!ss.str().empty()) {
             output_queue.push(ss.str());
           }

--- a/recipes/indexlr.cpp
+++ b/recipes/indexlr.cpp
@@ -248,7 +248,7 @@ main(int argc, char* argv[])
       out = fopen(outfile.c_str(), "w"); // NOLINT(android-cloexec-fopen)
 #endif
     }
-    for (auto& infile : infiles) {
+    for (const auto& infile : infiles) {
       std::unique_ptr<btllib::Indexlr> indexlr;
       if (with_repeat && with_solid) {
         flags |= btllib::Indexlr::Flag::FILTER_IN;

--- a/recipes/mi_bloom_filter.cpp
+++ b/recipes/mi_bloom_filter.cpp
@@ -216,14 +216,14 @@ main(int argc, char* argv[])
       std::cout << "verbose" << std::endl;
     }
 
-    std::vector<std::string> read_paths(&argv[optind], &argv[argc]);
+    const std::vector<std::string> read_paths(&argv[optind], &argv[argc]);
     if (argc < 2 || failed) {
       std::cout << std::endl;
       print_usage();
       std::exit(EXIT_FAILURE); // NOLINT(concurrency-mt-unsafe)
     }
-    std::map<std::string, ID_type> read_ids;
-    unsigned kmer_count =
+    const std::map<std::string, ID_type> read_ids;
+    const unsigned kmer_count =
       assert_id_size_and_count_kmers(read_paths, by_file, kmer_size);
 
     if (expected_elements > 0 || occupancy_set) {

--- a/recipes/mi_bloom_filter.cpp
+++ b/recipes/mi_bloom_filter.cpp
@@ -247,7 +247,7 @@ main(int argc, char* argv[])
     for (int mi_bf_stage = 0; mi_bf_stage < 3; mi_bf_stage++) {
       btllib::log_info(stages[mi_bf_stage] + std::string(" stage started"));
 
-      for (auto& read_path : read_paths) {
+      for (const auto& read_path : read_paths) {
         btllib::SeqReader reader(read_path,
                                  btllib::SeqReader::Flag::SHORT_MODE,
                                  DEFAULT_SEQ_READER_THREADS);

--- a/recipes/randseq.cpp
+++ b/recipes/randseq.cpp
@@ -145,14 +145,15 @@ public:
         std::lround((double)generated_seqs / (double)total_seqs * 100.0);
       const double seq_ratio =
         ((double)total_seqs - (double)generated_seqs) / (double)generated_seqs;
-      const std::chrono::duration<double> total_elapsed = (current_time - start_time);
+      const std::chrono::duration<double> total_elapsed =
+        (current_time - start_time);
       auto remaining = std::lround(seq_ratio * total_elapsed.count() + 1);
       const std::string line = "[" + std::to_string(generated_seqs) + "/" +
-                         std::to_string(total_seqs) + "] Generated " +
-                         std::to_string(generated_bp) + unit + " @" +
-                         std::to_string(speed) + unit + "/s (" +
-                         std::to_string(progress) + "%, ~" +
-                         std::to_string(remaining) + "s remaining)";
+                               std::to_string(total_seqs) + "] Generated " +
+                               std::to_string(generated_bp) + unit + " @" +
+                               std::to_string(speed) + unit + "/s (" +
+                               std::to_string(progress) + "%, ~" +
+                               std::to_string(remaining) + "s remaining)";
       std::cerr << line << "\r";
       last_log = current_time;
       last_line_length = line.size();

--- a/recipes/randseq.cpp
+++ b/recipes/randseq.cpp
@@ -137,17 +137,17 @@ public:
     generated_bp += seq_len;
     ++generated_seqs;
     auto current_time = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed = (current_time - last_log);
+    const std::chrono::duration<double> elapsed = (current_time - last_log);
     if (elapsed.count() > LOG_DELAY_SECONDS) {
-      long double diff_bp = generated_bp - last_generated_bp;
+      const long double diff_bp = generated_bp - last_generated_bp;
       auto speed = std::llround(diff_bp / elapsed.count());
       auto progress =
         std::lround((double)generated_seqs / (double)total_seqs * 100.0);
-      double seq_ratio =
+      const double seq_ratio =
         ((double)total_seqs - (double)generated_seqs) / (double)generated_seqs;
-      std::chrono::duration<double> total_elapsed = (current_time - start_time);
+      const std::chrono::duration<double> total_elapsed = (current_time - start_time);
       auto remaining = std::lround(seq_ratio * total_elapsed.count() + 1);
-      std::string line = "[" + std::to_string(generated_seqs) + "/" +
+      const std::string line = "[" + std::to_string(generated_seqs) + "/" +
                          std::to_string(total_seqs) + "] Generated " +
                          std::to_string(generated_bp) + unit + " @" +
                          std::to_string(speed) + unit + "/s (" +
@@ -163,7 +163,7 @@ public:
   void stop()
   {
     auto end_time = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed = (end_time - start_time);
+    const std::chrono::duration<double> elapsed = (end_time - start_time);
     std::cerr << std::string(last_line_length, ' ') << "\r";
     std::cerr << "Generated " << generated_seqs << " sequence(s) (total "
               << generated_bp << unit << ") in " << elapsed.count() << "s"
@@ -175,7 +175,7 @@ int
 main(int argc, char** argv)
 {
   try {
-    Arguments args(argc, argv);
+    const Arguments args(argc, argv);
     omp_set_num_threads(args.num_threads);
 
     // Random generator for sequence lengths
@@ -191,13 +191,13 @@ main(int argc, char** argv)
       rnd.set_seed(args.seed);
     }
 
-    std::string unit =
+    const std::string unit =
       args.seq_type == btllib::RandSeq::SeqType::PROTEIN ? "aa" : "bp";
     Logger log(args.num_sequences, unit);
 
 #pragma omp parallel for shared(args, rnd, rng, dist, writer, log) default(none)
     for (unsigned i = 0; i < args.num_sequences; i++) {
-      std::string seq = rnd.generate(dist(rng));
+      const std::string seq = rnd.generate(dist(rng));
       writer.write(std::to_string(i + 1), "", seq, "");
 #pragma omp critical
       log.add_sequence(seq.size());

--- a/scripts/code-coverage
+++ b/scripts/code-coverage
@@ -5,7 +5,7 @@ if [ -z "${MESON_BUILD_ROOT}" ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_BUILD_ROOT}"
 

--- a/scripts/docs
+++ b/scripts/docs
@@ -5,7 +5,7 @@ if [ -z "${MESON_SOURCE_ROOT}" ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}"
 

--- a/scripts/get-files
+++ b/scripts/get-files
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 if [ -z "${MESON_SOURCE_ROOT}" ]; then
   echo "[ERROR] This script can only be ran with meson!"

--- a/scripts/get-include-relative
+++ b/scripts/get-include-relative
@@ -10,7 +10,7 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}"
 

--- a/scripts/get-python-flags
+++ b/scripts/get-python-flags
@@ -34,7 +34,7 @@ set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}"
 
-if [[ -n "$BTLLIB_PYTHON_CFLAGS" ]]; then
+if [[ -n "${BTLLIB_PYTHON_CFLAGS+x}" ]]; then
   cflags="$BTLLIB_PYTHON_CFLAGS"
   ldflags="$BTLLIB_PYTHON_LDFLAGS"
 else

--- a/scripts/get-python-flags
+++ b/scripts/get-python-flags
@@ -30,7 +30,7 @@ get_libs() {
   echo "$libsfound"
 }
 
-set -e
+set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}"
 

--- a/scripts/get-tests
+++ b/scripts/get-tests
@@ -5,7 +5,7 @@ if [ -z "${MESON_SOURCE_ROOT}" ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}"
 

--- a/scripts/install-cpptoml
+++ b/scripts/install-cpptoml
@@ -5,6 +5,8 @@ if [ -z "${MESON_SOURCE_ROOT}" ]; then
   exit 1
 fi
 
+set -euo pipefail
+
 mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/include"
 
 cp "${MESON_SOURCE_ROOT}/subprojects/cpptoml/include/cpptoml.h" "${DESTDIR}/${MESON_INSTALL_PREFIX}/include/btllib/"

--- a/scripts/install-cpptoml
+++ b/scripts/install-cpptoml
@@ -7,6 +7,9 @@ fi
 
 set -euo pipefail
 
+# Set DESTDIR to empty string if not set
+DESTDIR="${DESTDIR:-}"
+
 mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/include"
 
 cp "${MESON_SOURCE_ROOT}/subprojects/cpptoml/include/cpptoml.h" "${DESTDIR}/${MESON_INSTALL_PREFIX}/include/btllib/"

--- a/scripts/install-sdsl-lite
+++ b/scripts/install-sdsl-lite
@@ -5,6 +5,8 @@ if [ -z "${MESON_SOURCE_ROOT}" ]; then
   exit 1
 fi
 
+set -euo pipefail
+
 mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/include"
 
 cp -r "${MESON_SOURCE_ROOT}/subprojects/sdsl-lite/include/sdsl" "${DESTDIR}/${MESON_INSTALL_PREFIX}/include/btllib/"

--- a/scripts/install-sdsl-lite
+++ b/scripts/install-sdsl-lite
@@ -7,6 +7,9 @@ fi
 
 set -euo pipefail
 
+# Set DESTDIR to empty string if not set
+DESTDIR="${DESTDIR:-}"
+
 mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/include"
 
 cp -r "${MESON_SOURCE_ROOT}/subprojects/sdsl-lite/include/sdsl" "${DESTDIR}/${MESON_INSTALL_PREFIX}/include/btllib/"

--- a/scripts/portable_realpath
+++ b/scripts/portable_realpath
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # MacOS does not necessarily have coreutils installed, but Python should be as btllib requires it
 function portable_realpath() {
   python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $1

--- a/scripts/prepare-sdsl
+++ b/scripts/prepare-sdsl
@@ -5,7 +5,7 @@ if [ -z "${MESON_SOURCE_ROOT}" ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}/subprojects/sdsl-lite"
 

--- a/scripts/quality-assurance
+++ b/scripts/quality-assurance
@@ -5,7 +5,7 @@ if [ -z "${MESON_BUILD_ROOT}" ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_BUILD_ROOT}"
 

--- a/scripts/sanitize
+++ b/scripts/sanitize
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 if [ -z "${MESON_SOURCE_ROOT}" ]; then
   echo "[ERROR] This script can only be ran with meson!"

--- a/scripts/test-wrappers
+++ b/scripts/test-wrappers
@@ -5,7 +5,7 @@ if [ -z "${MESON_SOURCE_ROOT}" ]; then
   exit 1
 fi
 
-set -e
+set -euo pipefail
 
 cd "${MESON_SOURCE_ROOT}"
 

--- a/src/btllib/aahash.cpp
+++ b/src/btllib/aahash.cpp
@@ -32,7 +32,7 @@ AAHash::init()
     pos = std::numeric_limits<std::size_t>::max();
     return false;
   }
-  uint64_t hash_value = aahash_base(seq + pos, k, level);
+  const uint64_t hash_value = aahash_base(seq + pos, k, level);
   nte64(hash_value, k, hash_num, hashes_array.get());
   initialized = true;
   return true;
@@ -51,7 +51,7 @@ AAHash::roll()
     pos += k;
     return init();
   }
-  uint64_t hash_value =
+  const uint64_t hash_value =
     aahash_roll(hashes_array[0], k, seq[pos], seq[pos + k], level);
   nte64(hash_value, k, hash_num, hashes_array.get());
   ++pos;

--- a/src/btllib/nthash.cpp
+++ b/src/btllib/nthash.cpp
@@ -273,7 +273,8 @@ parse_seeds(const std::vector<std::string>& seed_strings,
       }
     }
     const unsigned num_cares = care_blocks.size() * 2 + care_monos.size();
-    const unsigned num_ignores = ignore_blocks.size() * 2 + ignore_monos.size() + 2;
+    const unsigned num_ignores =
+      ignore_blocks.size() * 2 + ignore_monos.size() + 2;
     if (num_ignores < num_cares) {
       unsigned string_end = seed_string.length();
       const std::array<unsigned, 2> block{ { 0, string_end } };

--- a/src/btllib/nthash.cpp
+++ b/src/btllib/nthash.cpp
@@ -245,7 +245,7 @@ parse_seeds(const std::vector<std::string>& seed_strings,
             std::vector<SpacedSeedMonomers>& out_monomers)
 {
   for (const auto& seed_string : seed_strings) {
-    char pad = seed_string[seed_string.length() - 1] == '1' ? '0' : '1';
+    const char pad = seed_string[seed_string.length() - 1] == '1' ? '0' : '1';
     const std::string padded_string = seed_string + pad;
     SpacedSeedBlocks care_blocks, ignore_blocks;
     std::vector<unsigned> care_monos, ignore_monos;
@@ -256,7 +256,7 @@ parse_seeds(const std::vector<std::string>& seed_strings,
         if (pos - i_start == 1) {
           care_monos.push_back(i_start);
         } else {
-          std::array<unsigned, 2> block{ { i_start, pos } };
+          const std::array<unsigned, 2> block{ { i_start, pos } };
           care_blocks.push_back(block);
         }
         i_start = pos;
@@ -265,18 +265,18 @@ parse_seeds(const std::vector<std::string>& seed_strings,
         if (pos - i_start == 1) {
           ignore_monos.push_back(i_start);
         } else {
-          std::array<unsigned, 2> block{ { i_start, pos } };
+          const std::array<unsigned, 2> block{ { i_start, pos } };
           ignore_blocks.push_back(block);
         }
         i_start = pos;
         is_care_block = true;
       }
     }
-    unsigned num_cares = care_blocks.size() * 2 + care_monos.size();
-    unsigned num_ignores = ignore_blocks.size() * 2 + ignore_monos.size() + 2;
+    const unsigned num_cares = care_blocks.size() * 2 + care_monos.size();
+    const unsigned num_ignores = ignore_blocks.size() * 2 + ignore_monos.size() + 2;
     if (num_ignores < num_cares) {
       unsigned string_end = seed_string.length();
-      std::array<unsigned, 2> block{ { 0, string_end } };
+      const std::array<unsigned, 2> block{ { 0, string_end } };
       ignore_blocks.push_back(block);
       out_blocks.push_back(ignore_blocks);
       out_monomers.push_back(ignore_monos);


### PR DESCRIPTION
Enabled strict mode in bash scripts so that they fail if any of the commands fail (ask requested in https://github.com/bcgsc/btllib/issues/98).
Additionally fixed clang-tidy complaints regarding setting vars to `const` that can be constant.