### PR TITLE
MacOS CI Fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - script: |
       source activate btllib_CI
       conda install --yes -c conda-forge mamba
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers=1.7.0 clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: Install dependencies
   
   - script: |
@@ -94,7 +94,7 @@ jobs:
 
   - script: |
       source activate btllib_CI      
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers=1.7.0 llvm clang-format clang-tools boost 'samtools>=1.14' coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers llvm clang-format clang-tools boost 'samtools>=1.14' coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: 'Install required software'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
 
   - script: |
       source activate btllib_CI
-      ninja test && ninja code-coverage
+      cd build && ninja test && ninja code-coverage
     displayName: 'Run code coverage tests'
 
 - job: macos

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - script: |
       source activate btllib_CI
       conda install --yes -c conda-forge mamba
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: Install dependencies
   
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,6 @@ jobs:
 
   - script: |
       source activate btllib_CI
-#      mamba install --yes -c conda-forge meson=1.4.0
-#      rm -r build && meson setup build && cd build && ninja
       ninja test && ninja code-coverage
     displayName: 'Run code coverage tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ jobs:
       source activate btllib_CI
       conda install --yes -c conda-forge mamba
       mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp
+      pip install gcovr
     displayName: Install dependencies
   
   - script: |
@@ -64,7 +65,6 @@ jobs:
 
   - script: |
       source activate btllib_CI
-      pip install gcovr
       cd build && ninja test && ninja code-coverage
     displayName: 'Run code coverage tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,11 +43,6 @@ jobs:
 
   - script: |
       source activate btllib_CI
-      cd build && ninja clang-tidy
-    displayName: 'Run clang-tidy'
-
-  - script: |
-      source activate btllib_CI
       cd build && meson test --repeat=5 --print-errorlogs
     displayName: 'Run tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - script: |
       source activate btllib_CI
       conda install --yes -c conda-forge mamba
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers=1.7.0 clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: Install dependencies
   
   - script: |
@@ -94,7 +94,7 @@ jobs:
 
   - script: |
       source activate btllib_CI      
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers llvm clang-format clang-tools boost 'samtools>=1.14' coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers=1.7.0 llvm clang-format clang-tools boost 'samtools>=1.14' coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: 'Install required software'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - script: |
       source activate btllib_CI
       conda install --yes -c conda-forge mamba
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp
     displayName: Install dependencies
   
   - script: |
@@ -64,6 +64,7 @@ jobs:
 
   - script: |
       source activate btllib_CI
+      pip install gcovr
       cd build && ninja test && ninja code-coverage
     displayName: 'Run code coverage tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,8 @@ jobs:
 
   - script: |
       source activate btllib_CI
-      mamba install --yes -c conda-forge meson=1.4.0
-      rm -r build && meson setup build && cd build && ninja
+#      mamba install --yes -c conda-forge meson=1.4.0
+#      rm -r build && meson setup build && cd build && ninja
       ninja test && ninja code-coverage
     displayName: 'Run code coverage tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - script: |
       source activate btllib_CI
       conda install --yes -c conda-forge mamba
-      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
+      mamba install --yes -c conda-forge -c bioconda libcxx compilers clang llvm clang-format=18 clang-tools boost samtools coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: Install dependencies
   
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,16 +82,23 @@ jobs:
   - checkout: self
     persistCredentials: true
     submodules: recursive
+
   - script: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      conda update -n base -y -c defaults conda
-    displayName: Add conda to PATH
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
+
   - script: conda create --yes --quiet --name btllib_CI
     displayName: Create Anaconda environment
 
   - script: |
       source activate btllib_CI      
-      conda install --yes -c conda-forge mamba
       mamba install --yes -c conda-forge -c bioconda libcxx compilers llvm clang-format clang-tools boost 'samtools>=1.14' coreutils xz lrzip meson ninja cmake openmp gcovr
     displayName: 'Install required software'
 

--- a/src/btllib/status.cpp
+++ b/src/btllib/status.cpp
@@ -33,7 +33,7 @@ log_info(const std::string& msg)
 {
   std::string info_msg = "[" + get_time() + "]" + PRINT_COLOR_INFO + "[INFO] " +
                          PRINT_COLOR_END + msg + "\n";
-  std::cerr << info_msg << std::flush;
+  std::cerr << info_msg << std::endl;
 }
 
 void
@@ -41,7 +41,7 @@ log_warning(const std::string& msg)
 {
   std::string warning_msg = "[" + get_time() + "]" + PRINT_COLOR_WARNING +
                             "[WARNING] " + PRINT_COLOR_END + msg + "\n";
-  std::cerr << warning_msg << std::flush;
+  std::cerr << warning_msg << std::endl;
 }
 
 void
@@ -49,7 +49,7 @@ log_error(const std::string& msg)
 {
   std::string error_msg = "[" + get_time() + "]" + PRINT_COLOR_ERROR +
                           "[ERROR] " + PRINT_COLOR_END + msg + "\n";
-  std::cerr << error_msg << std::flush;
+  std::cerr << error_msg << std::endl;
 }
 
 void

--- a/src/btllib/status.cpp
+++ b/src/btllib/status.cpp
@@ -31,25 +31,25 @@ get_time()
 void
 log_info(const std::string& msg)
 {
-  std::cerr << ('[' + get_time() + "]" + PRINT_COLOR_INFO + "[INFO] " +
-                PRINT_COLOR_END + msg + '\n')
-            << std::flush;
+  std::string info_msg = '[' + get_time() + "]" + PRINT_COLOR_INFO + "[INFO] " +
+                         PRINT_COLOR_END + msg + '\n';
+  std::cerr << info_msg << std::flush;
 }
 
 void
 log_warning(const std::string& msg)
 {
-  std::cerr << ('[' + get_time() + "]" + PRINT_COLOR_WARNING + "[WARNING] " +
-                PRINT_COLOR_END + msg + '\n')
-            << std::flush;
+  std::string warning_msg = '[' + get_time() + "]" + PRINT_COLOR_WARNING +
+                            "[WARNING] " + PRINT_COLOR_END + msg + '\n';
+  std::cerr << warning_msg << std::flush;
 }
 
 void
 log_error(const std::string& msg)
 {
-  std::cerr << ('[' + get_time() + "]" + PRINT_COLOR_ERROR + "[ERROR] " +
-                PRINT_COLOR_END + msg + '\n')
-            << std::flush;
+  std::string error_msg = '[' + get_time() + "]" + PRINT_COLOR_ERROR +
+                          "[ERROR] " + PRINT_COLOR_END + msg + '\n';
+  std::cerr << error_msg << std::flush;
 }
 
 void

--- a/src/btllib/status.cpp
+++ b/src/btllib/status.cpp
@@ -32,7 +32,7 @@ void
 log_info(const std::string& msg)
 {
   std::string info_msg = "[" + get_time() + "]" + PRINT_COLOR_INFO + "[INFO] " +
-                         PRINT_COLOR_END + msg + "\n";
+                         PRINT_COLOR_END + msg;
   std::cerr << info_msg << std::endl;
 }
 
@@ -40,7 +40,7 @@ void
 log_warning(const std::string& msg)
 {
   std::string warning_msg = "[" + get_time() + "]" + PRINT_COLOR_WARNING +
-                            "[WARNING] " + PRINT_COLOR_END + msg + "\n";
+                            "[WARNING] " + PRINT_COLOR_END + msg;
   std::cerr << warning_msg << std::endl;
 }
 
@@ -48,7 +48,7 @@ void
 log_error(const std::string& msg)
 {
   std::string error_msg = "[" + get_time() + "]" + PRINT_COLOR_ERROR +
-                          "[ERROR] " + PRINT_COLOR_END + msg + "\n";
+                          "[ERROR] " + PRINT_COLOR_END + msg;
   std::cerr << error_msg << std::endl;
 }
 

--- a/src/btllib/status.cpp
+++ b/src/btllib/status.cpp
@@ -31,24 +31,24 @@ get_time()
 void
 log_info(const std::string& msg)
 {
-  std::string info_msg = '[' + get_time() + "]" + PRINT_COLOR_INFO + "[INFO] " +
-                         PRINT_COLOR_END + msg + '\n';
+  std::string info_msg = "[" + get_time() + "]" + PRINT_COLOR_INFO + "[INFO] " +
+                         PRINT_COLOR_END + msg + "\n";
   std::cerr << info_msg << std::flush;
 }
 
 void
 log_warning(const std::string& msg)
 {
-  std::string warning_msg = '[' + get_time() + "]" + PRINT_COLOR_WARNING +
-                            "[WARNING] " + PRINT_COLOR_END + msg + '\n';
+  std::string warning_msg = "[" + get_time() + "]" + PRINT_COLOR_WARNING +
+                            "[WARNING] " + PRINT_COLOR_END + msg + "\n";
   std::cerr << warning_msg << std::flush;
 }
 
 void
 log_error(const std::string& msg)
 {
-  std::string error_msg = '[' + get_time() + "]" + PRINT_COLOR_ERROR +
-                          "[ERROR] " + PRINT_COLOR_END + msg + '\n';
+  std::string error_msg = "[" + get_time() + "]" + PRINT_COLOR_ERROR +
+                          "[ERROR] " + PRINT_COLOR_END + msg + "\n";
   std::cerr << error_msg << std::flush;
 }
 


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit
* Small changes to CI so tests pass
  * Install `gcovr` using `pip` - newer version not on conda
  * Updates to `status.cpp` for macos sanitize undefined failures