### PR TITLE
Raise error when filename has spaces

### DIFF
--- a/src/btllib/seq_reader.cpp
+++ b/src/btllib/seq_reader.cpp
@@ -59,6 +59,8 @@ SeqReader::SeqReader(const std::string& source_path,
   check_error(short_mode() && long_mode(),
               "SeqReader: short and long mode are mutually exclusive.");
   check_error(threads == 0, "SeqReader: Number of helper threads cannot be 0.");
+  check_error(source_path.find(' ') != std::string::npos,
+              "SeqReader: filename cannot include spaces");
   start_processors();
   {
     std::unique_lock<std::mutex> lock(format_mutex);

--- a/src/btllib/seq_writer.cpp
+++ b/src/btllib/seq_writer.cpp
@@ -16,6 +16,8 @@ SeqWriter::SeqWriter(const std::string& sink_path, Format format, bool append)
   , format(format)
   , headerchar(format == FASTA ? '>' : '@')
 {
+  check_error(sink_path.find(' ') != std::string::npos,
+              "SeqWriter: filename cannot include spaces");
 }
 
 void


### PR DESCRIPTION
Addresses #129

Attempted to fix by:
- putting the path in quotes interprets input as two files with one starting with quotes and the other ending with one.
- adding a backslash before each space, similar to quotes, interprets one file ending with `\`
- using `std::filesystem::exists` instead of `stat` and `std::filesystem::path(source_path).u8string()`, no change

Added a `check_error` for this case to provide user with a verbose error message.