### PR TITLE
test-wrappers: use python3

### DIFF
--- a/scripts/test-wrappers
+++ b/scripts/test-wrappers
@@ -12,4 +12,4 @@ cp -r "${MESON_BUILD_ROOT}/wrappers/python" "${MESON_BUILD_ROOT}/wrappers/btllib
 cp "${MESON_SOURCE_ROOT}/wrappers/python/btllib.py" "${MESON_BUILD_ROOT}/wrappers/btllib/__init__.py"
 export PYTHONPATH="${MESON_BUILD_ROOT}/wrappers/"
 cd "${MESON_SOURCE_ROOT}/tests/python"
-python -m unittest
+python3 -m unittest


### PR DESCRIPTION
We needed this patch for the Debian package